### PR TITLE
hotfix: moved to conditional importing and getattr all

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,3 +22,4 @@ min_read_pairs: 200
 max_perc_adapter: 5
 skip_anno: false
 pooling: true
+stage: preprocess

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,6 +27,10 @@ configfile: os.path.join(workflow.basedir, "../config/config.yaml")
 localrules:
     all,
 
+
+all_stages = ["demux", "annotate", "denoise", "preprocess"]
+assert config["stage"] in all_stages, f"stage must be one the following: {all_stages}"
+
 if config["stage"] != "annotate":
     config["asv_fasta"] = f"denoise/{config['pool']}_asvs.fasta"
 
@@ -44,14 +48,12 @@ module demux:
         config
 
 
-use rule * from demux as demux_*
+if config["stage"] == "demux":
+    use rule * from demux as demux_*
+    config["primer_F"], config["primer_R"] = extract_primers(config)
 
-config["primer_F"], config["primer_R"] = extract_primers(config)
 
-# db_files = get_files_from_db_dir(config)
-# config["db_files"] = db_files
-#config["samples"] = clean_oligos_and_return_samples(input_files)
-#config["input_files"]["oligos"] = "tmp.oligos"
+
 
 
 module preprocess:
@@ -62,7 +64,8 @@ module preprocess:
     skip_validation: True
 
 
-use rule * from preprocess as preprocess_*
+if config["stage"] == "preprocess":
+    use rule * from preprocess as preprocess_*
 
 
 # note that the default pipeline
@@ -83,7 +86,8 @@ else:
             config
 
 
-use rule * from denoise as denoise_*
+if config["stage"] == "denoise":
+    use rule * from denoise as denoise_*
 
 
 module annotate:
@@ -94,7 +98,8 @@ module annotate:
     skip_validation: True
 
 
-use rule * from annotate as annotate_*
+if config["stage"] == "annotate":
+    use rule * from annotate as annotate_*
 
 
 if config["skip_anno"]:
@@ -105,38 +110,13 @@ if config["skip_anno"]:
             "annotation_skipped.txt",
 
 
-
-
 onstart:
     with open("config_used.yml", "w") as outfile:
         yaml.dump(config, outfile)
 
 
 
-
-outputs = {
-    # "all": [
-    #     rules.preprocess_all.input,
-    #     rules.demux_all.input,
-    #     rules.denoise_all.input,
-    #     rules.annotate_all.input,
-    # ],
-    "preprocess": [
-        rules.preprocess_all.input,
-    ],
-    "demux": [
-        rules.demux_all.input,
-    ],
-    "denoise": [
-        rules.denoise_all.input,
-    ],
-    "annotate": [
-        rules.annotate_all.input,
-    ],
-}
-
-
 rule all:
     input:
-        outputs[config["stage"]],
+        getattr(rules, f"{config['stage']}_all").input
     default_target: True


### PR DESCRIPTION
Taking lessons learned from the shotgun pipeline to ensure that the pipeline doesn't try to use config entries not needed for the current stage.

- Update documentation to have a snakemake profile as a prerequisite
- Update docs to remove unneeded args and add stage arg
- getattr all rule same as shotgun pipeline
- `use rule * from <x> as <x>_*` calls are now conditional on stage